### PR TITLE
Soap Trace Output to STDERR

### DIFF
--- a/lib/docusign/docusignDriver.rb
+++ b/lib/docusign/docusignDriver.rb
@@ -373,6 +373,7 @@ class APIServiceSoap < ::SOAP::RPC::Driver
     super(endpoint_url, nil)
     self.mapping_registry = DefaultMappingRegistry::EncodedRegistry
     self.literal_mapping_registry = DefaultMappingRegistry::LiteralRegistry
+    self.wiredump_dev=STDERR if Rails.env == "development" rescue nil
     init_methods
   end
 


### PR DESCRIPTION
While going through the certification process with Russ, he requested a SOAP Trace. I've added a line to the docusignDriver.rb APIServiceSoap class which will output this trace to STDERR automatically when the rails app is run in the development environment. This will work for modern (tested 2.3.2 and up) versions of rails, but may not in older versions, so I put a rescue nil at the end of the line.
