### PR TITLE
New pull request for Ruby 1.9 support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@
 require 'rubygems'
 require './lib/docusign.rb'
 
-gem 'soap4r'
+gem 'mumboe-soap4r'
 require 'wsdl/soap/wsdl2ruby'
 
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -42,6 +42,13 @@ task :cultivate do
   system "rake debug_gem | grep -v \"(in \" > `basename \\`pwd\\``.gemspec"
 end
 
+#Test tasks
+require 'rspec'
+require 'rspec/core/rake_task'
+desc 'Run the unit tests'
+RSpec::Core::RakeTask.new(:test)
+#End test tasks
+
 namespace :docusign do
   namespace :services do
     desc "Generate SOAP stubs for Docusign API"

--- a/lib/docusign.rb
+++ b/lib/docusign.rb
@@ -15,7 +15,7 @@
 		 
 $LOAD_PATH << File.expand_path(File.dirname(__FILE__))
  
-gem 'soap4r'
+gem 'mumboe-soap4r'
 require 'active_support'
 
 require 'docusign/utilities'

--- a/lib/docusign.rb
+++ b/lib/docusign.rb
@@ -16,6 +16,7 @@
 $LOAD_PATH << File.expand_path(File.dirname(__FILE__))
  
 gem 'mumboe-soap4r'
+
 require 'active_support'
 
 require 'docusign/utilities'

--- a/lib/docusign/extensions.rb
+++ b/lib/docusign/extensions.rb
@@ -48,7 +48,7 @@ module AutoCamelize
   
   def ds_equivalent(string)
     string = string.to_s.camelize(:lower)
-    methods.find { |m| m.downcase == string.downcase }
+    methods.find { |m| m.to_s.downcase == string.downcase }
   end
 end
 

--- a/lib/docusign/request_recipient_token_client_urls.rb
+++ b/lib/docusign/request_recipient_token_client_urls.rb
@@ -2,6 +2,6 @@ module Docusign
   class RequestRecipientTokenClientURLs
     # List all callback names, underscored, without the leading "on_"
     # eg. 'session_timeout', 'signing_complete', etc.
-    CALLBACKS = instance_methods.select { |m| m =~ /^on/ }.reject { |m| m =~ /=/ }.map { |m| m.gsub(/^on/, '').underscore }
+    CALLBACKS = instance_methods.collect {|m| m.to_s}.select { |m| m =~ /^on/ }.reject { |m| m =~ /=/ }.map { |m| m.gsub(/^on/, '').underscore }
   end
 end

--- a/spec/docusign/builder/anchor_builder_spec.rb
+++ b/spec/docusign/builder/anchor_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Docusign::Builder::AnchorBuilder do
   describe "#initialize" do

--- a/spec/docusign/builder/tab_builder_spec.rb
+++ b/spec/docusign/builder/tab_builder_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Docusign::Builder::TabBuilder do
   def init_tab_builder

--- a/spec/docusign/document_spec.rb
+++ b/spec/docusign/document_spec.rb
@@ -1,4 +1,4 @@
-require 'spec/spec_helper'
+require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Docusign::Document do
   before(:each) do


### PR DESCRIPTION
Here are my other changes.  As you mentioned, probably having a ruby 1.9 branch people go pull and experiment with would be good.  They could change their Gemfile to point to the branch on github.  Like:
gem "docusign", :git => "git://github.com/texel/docusign", :branch => 'ruby19_exp'

Scott
